### PR TITLE
Using delete_all instead of destroy_all to avoid object initialization

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,7 +3,7 @@ class Post < ActiveRecord::Base
   validates :url, uniqueness: true
 
   def self.sync
-    Post.destroy_all
+    Post.delete_all
     sources.each do |source|
       source.new.translate.each_with_index do |hash, index|
         Post.create hash.merge(source: source.name.demodulize, position: index)


### PR DESCRIPTION
`.destroy_all` initializes every object before deleting it, since there are no relations or callbacks that is not needed. 

Using `.delete_all` instead will simply execute `DELETE FROM posts` request, which is much faster.
