### PR TITLE
Add missing indexes to posts

### DIFF
--- a/db/migrate/20141214195255_add_missing_indexes_to_posts.rb
+++ b/db/migrate/20141214195255_add_missing_indexes_to_posts.rb
@@ -1,0 +1,6 @@
+class AddMissingIndexesToPosts < ActiveRecord::Migration
+  def change
+    add_index :posts, :url, unique: true
+    add_index :posts, [ :source, :position ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141123202347) do
+ActiveRecord::Schema.define(version: 20141214195255) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,5 +43,8 @@ ActiveRecord::Schema.define(version: 20141123202347) do
     t.datetime "updated_at"
     t.integer  "comment_count"
   end
+
+  add_index "posts", ["source", "position"], name: "index_posts_on_source_and_position", using: :btree
+  add_index "posts", ["url"], name: "index_posts_on_url", unique: true, using: :btree
 
 end


### PR DESCRIPTION
I noticed missing indexes on _posts_ and added them:

`url` — unique index that is used on every post creation, since there's a uniqueness validation
`:source, :position` — when posts are fetch they are sorted by position, and sometimes filtered by source, combined index ensures both requests will use this index
