### PR TITLE
Using Typhoeus::Hydra to speed up HackerNews sync by executing parallel requests

### DIFF
--- a/lib/source/base.rb
+++ b/lib/source/base.rb
@@ -30,14 +30,18 @@ module Source
       # the base string of the url for the api
     end
 
-    def get(url, options = {}, headers = {})
-      response = Typhoeus.get(api + url + '.json', params: options, headers: headers)
+    def get(path, options = {}, headers = {})
+      response = Typhoeus.get(url_for(path), params: options, headers: headers)
       JSON.parse(response.body)
     end
 
-    def post(url, options = {})
-      response = Typhoeus.post(api + url + '.json', params: options)
+    def post(path, options = {})
+      response = Typhoeus.post(url_for(path), params: options)
       JSON.parse(response.body)
+    end
+
+    def url_for(path)
+      api + path + '.json'
     end
   end
 end


### PR DESCRIPTION
HackerNews allows you to fetch a single post at a time, which is painfully slow, so I decided to speed it up.

So instead of executing requests one by one, I've added `Typhoeus::Hydra` (since `Typhoeus` is already used in the project) to start multiple requests in parallel.

Here are some performance tests:

```
1: bundle exec rake posts:sync  2.55s user 0.48s system 2% cpu 1:43.32 total
2: bundle exec rake posts:sync  2.50s user 0.47s system 5% cpu 52.591 total
4: bundle exec rake posts:sync  2.47s user 0.47s system 7% cpu 38.781 total
8: bundle exec rake posts:sync  2.42s user 0.45s system 13% cpu 21.417 total
16: bundle exec rake posts:sync  2.30s user 0.43s system 20% cpu 13.444 total
```

These tests can not be taken too seriously, since my internet connection is not that great or stable, but a positive trend is very obvious.

I've kept the `CONCURRENCY` constant at 8, because it seems to be the most optimal CPU/time wise.
