### PR TITLE
Delay removal of posts

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -3,10 +3,11 @@ class Post < ActiveRecord::Base
   validates :url, uniqueness: true
 
   def self.sync
-    Post.delete_all
     sources.each do |source|
-      source.new.translate.each_with_index do |hash, index|
-        Post.create hash.merge(source: source.name.demodulize, position: index)
+      post_attributes = source.new.translate
+      Post.where(source: source.feed_name).delete_all
+      post_attributes.each_with_index do |hash, index|
+        Post.create hash.merge(source: source.feed_name, position: index)
       end
     end
   end

--- a/lib/source/base.rb
+++ b/lib/source/base.rb
@@ -14,6 +14,10 @@ module Source
       # string of brand symbol
     end
 
+    def self.feed_name
+      name.demodulize
+    end
+
     def feed_items
       # Should return a json array of the items in the feed
     end

--- a/spec/factories/posts.rb
+++ b/spec/factories/posts.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :post do
-    source { Post.sources.sample.name.demodulize }
+    source { Post.sources.sample.feed_name }
     sequence(:url) {|n| "http://www.example-#{n}.com" }
     title 'A Post'
     comments 'http://www.example.com/comments'

--- a/spec/lib/source/base_spec.rb
+++ b/spec/lib/source/base_spec.rb
@@ -1,6 +1,11 @@
 require 'source/base'
 
 describe Source::Base do
+  describe '#feed_name' do
+    it 'returns feed name' do
+      expect(Source::ProductHunt.feed_name).to eq('ProductHunt')
+    end
+  end
 
   describe '.translate' do
     let(:feed_items) { [1, 2, 3] }


### PR DESCRIPTION
A little change that will minimize the time with no posts in the DB. This is achieved by removing posts from a particular source only after the whole source feed was downloaded.